### PR TITLE
Tests refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /*.gem
 /Gemfile.lock
+spec/examples.txt

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,64 @@
+require:
+  - rubocop-performance
+  - rubocop-rails
+AllCops:
+  TargetRubyVersion: 2.7
+  NewCops: enable
+  SuggestExtensions: false
+
+Naming/MethodParameterName:
+  MinNameLength: 1
+Naming/VariableNumber:
+  Enabled: false
+
+Lint/MissingCopEnableDirective:
+  Enabled: false
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: false
+Layout/LineLength:
+  Max: 120
+Layout/MultilineOperationIndentation:
+  Enabled: false
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented_relative_to_receiver
+
+Style/AsciiComments:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/Documentation:
+  Enabled: false
+Style/FormatStringToken:
+  Enabled: false
+Style/Lambda:
+  Enabled: false
+Style/LambdaCall:
+  Enabled: false
+Style/ModuleFunction:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    '%i': '()'
+    '%I': '()'
+    '%r': '{}'
+    '%w': '()'
+    '%W': '()'
+Style/SignalException:
+  EnforcedStyle: 'only_raise'
+
+Metrics/AbcSize:
+  Exclude:
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'spec/**/*'
+Metrics/BlockLength:
+  Exclude:
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'spec/**/*'
+Metrics/MethodLength:
+  Exclude:
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'spec/**/*'

--- a/spec/currencies_list_spec.rb
+++ b/spec/currencies_list_spec.rb
@@ -3,7 +3,8 @@
 require_relative './request_examples'
 
 describe CoinsPaid::API, '.currencies_list' do
-  endpoint = 'https://app.coinspaid.com/api/v2/currencies/list'
+  let(:endpoint) { 'https://app.coinspaid.com/api/v2/currencies/list' }
+  let(:request_body) { "{}" }
   include_context 'CoinsPaid API request'
 
   let(:expected_currencies) do
@@ -65,5 +66,5 @@ describe CoinsPaid::API, '.currencies_list' do
     expect(response).to match_array currencies
   end
 
-  it_behaves_like 'CoinsPaid API error handling', endpoint: endpoint
+  it_behaves_like 'CoinsPaid API error handling'
 end

--- a/spec/request_examples.rb
+++ b/spec/request_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_context 'CoinsPaid API request' do |request_data: {}|
+RSpec.shared_context 'CoinsPaid API request' do
   let(:signature) { 'c01dc0ffee' }
   let(:request_signature_headers) do
     {
@@ -10,11 +10,11 @@ RSpec.shared_context 'CoinsPaid API request' do |request_data: {}|
   end
 
   before do
-    allow(CoinsPaid::API::Signature).to receive(:generate).with(request_data.to_json).and_return signature
+    allow(CoinsPaid::API::Signature).to receive(:generate).with(request_body).and_return signature
   end
 end
 
-RSpec.shared_examples 'CoinsPaid API error handling' do |endpoint:, request_body: '{}'|
+RSpec.shared_examples 'CoinsPaid API error handling' do
   context 'when coins paid responded with validation errors' do
     let(:response_data) do
       {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,3 +10,10 @@ require 'webmock/rspec'
 require 'pry'
 require 'coins_paid_api'
 Dir['./spec/support/**/*.rb'].each { |f| require f }
+
+RSpec.configure do |config|
+  config.filter_run focus: true
+  config.alias_example_to :fit, focus: true
+  config.run_all_when_everything_filtered = true
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+end

--- a/spec/take_address_spec.rb
+++ b/spec/take_address_spec.rb
@@ -3,13 +3,17 @@
 require_relative './request_examples'
 
 describe CoinsPaid::API, '.take_address' do
-  endpoint = 'https://app.coinspaid.com/api/v2/addresses/take'
-  request_data = {
-    foreign_id: 'user-id:2048',
-    currency: 'BTC',
-    convert_to: 'EUR'
-  }
-  include_context 'CoinsPaid API request', request_data: request_data
+  let(:endpoint) { 'https://app.coinspaid.com/api/v2/addresses/take' }
+  let(:request_data) do
+    {
+      foreign_id: 'user-id:2048',
+      currency: 'BTC',
+      convert_to: 'EUR'
+    }
+  end
+  let(:request_body) { request_data.to_json }
+
+  include_context 'CoinsPaid API request'
 
   let(:expected_address_attributes) do
     {
@@ -35,11 +39,11 @@ describe CoinsPaid::API, '.take_address' do
 
   it 'returns valid response if successful' do
     stub_request(:post, endpoint)
-      .with(body: request_data, headers: request_signature_headers)
+      .with(body: request_body, headers: request_signature_headers)
       .to_return(status: 201, body: response_data.to_json)
 
     expect(take_address).to be_struct_with_params(CoinsPaid::API::TakeAddress::Response, expected_address_attributes)
   end
 
-  it_behaves_like 'CoinsPaid API error handling', endpoint: endpoint, request_body: request_data
+  it_behaves_like 'CoinsPaid API error handling'
 end

--- a/spec/withdrawal_spec.rb
+++ b/spec/withdrawal_spec.rb
@@ -2,10 +2,10 @@
 
 require_relative './request_examples'
 
-RSpec.shared_examples 'CoinsPaid API withdrawal' do |request_data:|
-  endpoint = 'https://app.coinspaid.com/api/v2/withdrawal/crypto'
+RSpec.shared_examples 'CoinsPaid API withdrawal' do
+  let(:endpoint) { 'https://app.coinspaid.com/api/v2/withdrawal/crypto' }
 
-  include_context 'CoinsPaid API request', request_data: request_data
+  include_context 'CoinsPaid API request'
 
   let(:response_data) do
     {
@@ -44,19 +44,24 @@ RSpec.shared_examples 'CoinsPaid API withdrawal' do |request_data:|
 end
 
 describe CoinsPaid::API, '.withdraw' do
-  base_request_data = {
-    foreign_id: 'user-id:2048',
-    amount: '0.01',
-    currency: 'EUR',
-    convert_to: 'BTC',
-    address: 'abc123'
-  }
+  let(:base_request_data) do
+    {
+      foreign_id: 'user-id:2048',
+      amount: '0.01',
+      currency: 'EUR',
+      convert_to: 'BTC',
+      address: 'abc123'
+    }
+  end
+  let(:request_body) { request_data.to_json }
 
   context 'request includes tag parameter' do
-    it_behaves_like 'CoinsPaid API withdrawal', request_data: base_request_data.merge(tag: 'thetag')
+    let(:request_data) { base_request_data.merge(tag: 'thetag') }
+    it_behaves_like 'CoinsPaid API withdrawal'
   end
 
   context 'request does not include tag parameter' do
-    it_behaves_like 'CoinsPaid API withdrawal', request_data: base_request_data
+    let(:request_data) { base_request_data }
+    it_behaves_like 'CoinsPaid API withdrawal'
   end
 end


### PR DESCRIPTION
We used local variables in tests unnecessary, which makes overriding them a bit awkward now. This PR refactors it and replaces all variable assignments with lets, and remove explicit parameters for shared examples/context blocks.