### PR TITLE
support no-conversion address requests

### DIFF
--- a/coins_paid_api.gemspec
+++ b/coins_paid_api.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name = 'coins_paid_api'
   s.authors = ['Artem Biserov(artembiserov)', 'Oleg Ivanov(morhekil)']
-  s.version = '1.0.7'
+  s.version = '1.1.0'
   s.files = `git ls-files`.split("\n")
   s.summary = 'Coins Paid Integration'
   s.license = 'MIT'

--- a/lib/coins_paid/api.rb
+++ b/lib/coins_paid/api.rb
@@ -35,7 +35,7 @@ module CoinsPaid
       yield self
     end
 
-    def take_address(foreign_id:, currency:, convert_to:)
+    def take_address(foreign_id:, currency:, convert_to: nil)
       Requester.call(
         TakeAddress,
         foreign_id: foreign_id, currency: currency, convert_to: convert_to

--- a/lib/coins_paid/api/take_address.rb
+++ b/lib/coins_paid/api/take_address.rb
@@ -6,7 +6,12 @@ module CoinsPaid
       class Request < Dry::Struct
         attribute :foreign_id, Types::Coercible::String
         attribute :currency, Types::String
-        attribute :convert_to, Types::String
+        attribute :convert_to, Types::String.optional
+
+        def to_hash
+          convert_value = convert_to != currency ? convert_to : nil
+          super().merge(convert_to: convert_value).compact
+        end
       end
 
       class Response < Dry::Struct

--- a/spec/take_address_spec.rb
+++ b/spec/take_address_spec.rb
@@ -4,46 +4,68 @@ require_relative './request_examples'
 
 describe CoinsPaid::API, '.take_address' do
   let(:endpoint) { 'https://app.coinspaid.com/api/v2/addresses/take' }
+
+  let(:foreign_id) { 'user-id:2048' }
+  let(:currency) { 'BTC' }
+
   let(:request_data) do
-    {
-      foreign_id: 'user-id:2048',
-      currency: 'BTC',
-      convert_to: 'EUR'
-    }
+    { foreign_id: foreign_id, currency: currency, convert_to: api_convert_to }.compact
   end
   let(:request_body) { request_data.to_json }
 
   include_context 'CoinsPaid API request'
-
-  let(:expected_address_attributes) do
-    {
-      external_id: 1,
-      address: '12983h13ro1hrt24it432t',
-      tag: '123'
-    }
-  end
-  subject(:take_address) { described_class.take_address(request_data) }
 
   let(:response_data) do
     {
       'data' => {
         'id' => 1,
         'currency' => 'BTC',
-        'convert_to' => 'EUR',
+        'convert_to' => api_convert_to,
         'address' => '12983h13ro1hrt24it432t',
         'tag' => 123,
         'foreign_id' => 'user-id:2048'
-      }
+      }.compact
     }
   end
 
-  it 'returns valid response if successful' do
-    stub_request(:post, endpoint)
-      .with(body: request_body, headers: request_signature_headers)
-      .to_return(status: 201, body: response_data.to_json)
+  let(:args) do
+    { foreign_id: 'user-id:2048', currency: 'BTC', convert_to: args_convert_to }.compact
+  end
+  subject(:take_address) { described_class.take_address(args) }
 
-    expect(take_address).to be_struct_with_params(CoinsPaid::API::TakeAddress::Response, expected_address_attributes)
+  shared_examples 'successful request' do
+    it 'returns valid response' do
+      stub_request(:post, endpoint)
+        .with(body: request_body, headers: request_signature_headers)
+        .to_return(status: 201, body: response_data.to_json)
+
+      expected_address_attributes = {
+        external_id: 1,
+        address: '12983h13ro1hrt24it432t',
+        tag: '123'
+      }
+      expect(take_address).to be_struct_with_params(
+        CoinsPaid::API::TakeAddress::Response, expected_address_attributes
+      )
+    end
   end
 
-  it_behaves_like 'CoinsPaid API error handling'
+  context 'with explicit convert_to not matching address currency' do
+    let(:args_convert_to) { 'EUR' }
+    let(:api_convert_to) { 'EUR' }
+    it_behaves_like 'successful request'
+    it_behaves_like 'CoinsPaid API error handling'
+  end
+
+  context 'with explicit convert_to matching address currency' do
+    let(:args_convert_to) { 'BTC' }
+    let(:api_convert_to) { nil }
+    it_behaves_like 'successful request'
+  end
+
+  context 'with nil convert_to' do
+    let(:args_convert_to) { nil }
+    let(:api_convert_to) { nil }
+    it_behaves_like 'successful request'
+  end
 end


### PR DESCRIPTION
If we want to take an address with no conversion applied to its deposits - we can't just send `"currency": "XXX", "convert_to": "XXX"` request. We need to remove `convert_to` completely.

This merge request implements correct behaviour when an explicit conversion parameter matches address currency: 

``` ruby
CoinsPaidApi.take_address(foreign_id: "user", currency: "USDTT", convert_to: "USDTT")
```

as well as when conversion parameter is omitted:

``` ruby
CoinsPaidApi.take_address(foreign_id: "user", currency: "USDTT")
```